### PR TITLE
Switch to use standard ILogger<T> instead of Console.WriteLine

### DIFF
--- a/BuzzAPISample.csproj
+++ b/BuzzAPISample.csproj
@@ -7,4 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/BuzzAPISample.csproj
+++ b/BuzzAPISample.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace BuzzAPISample
              *    If you're running the sample, you could use "BuzzAPISample"
              *      string applicationInformation = "BuzzAPISample";
              * 3. Configure buzzServerUrl, userspace, username, and password for your Buzz environment.
-             *    buzzServerUrl is typically "https://api.agilixbuzz.com"
+             *    buzzServerUrl is typically "https://background.api.agilixbuzz.com"  (see https://api.agilixbuzz.com/docs/#!/Concept/ApiTimeLimiting)
              *    userspace is the userspace of the domain where the login user resides
              *    username and password are the username and password of the login user
              */
@@ -26,7 +26,7 @@ namespace BuzzAPISample
             string userAgent = $"BuzzApiClient/1.0.0 (CSharp; {applicationInformation}; {contactInformation})";
 
             // Update these for your environment. Contact Agilix support if you need help.
-            string buzzServerUrl = ;
+            string buzzServerUrl = "https://backoff-test.agilixbuzz.com";   // (see https://api.agilixbuzz.com/docs/#!/Concept/ApiTimeLimiting)
             string userspace = ;
             string username = ;
             string password = ;


### PR DESCRIPTION
@paulbsmith can you review this.  I noticed that 429 Too Many Requests wasn't being handled correctly, so I fixed that, but while I was analyzing the code, I thought that removing references to Console.WriteLine would probably be a good idea so that it could be incorporated in a wider variety of apps.  ILogger<T> is the .NET standard for that, and it provides multiple verbosity levels.  I also added a bunch of comments and made some minor logic changes like always using the time the server specified in Retry-After instead of adding to it, and using the new exception filtering "when" clause in the retry loop.